### PR TITLE
Redesign dashboard layout with summary cards

### DIFF
--- a/src/asset_manager/web/app.py
+++ b/src/asset_manager/web/app.py
@@ -70,7 +70,7 @@ def _build_chart_html(records) -> tuple[dict[str, str], dict[str, float]]:
         dates = [point[0] for point in series]
         amounts = [float(point[1]) for point in series]
         fig_assets.add_trace(
-            go.Scatter(x=dates, y=amounts, name=description, mode="lines+markers")
+            go.Scatter(x=dates, y=amounts, name=description, mode="lines")
         )
     fig_assets.update_layout(
         title="Assets over Time",
@@ -90,7 +90,7 @@ def _build_chart_html(records) -> tuple[dict[str, str], dict[str, float]]:
         dates = [point[0] for point in series]
         amounts = [float(point[1]) for point in series]
         fig_liabilities.add_trace(
-            go.Scatter(x=dates, y=amounts, name=description, mode="lines+markers")
+            go.Scatter(x=dates, y=amounts, name=description, mode="lines")
         )
     fig_liabilities.update_layout(
         title="Liabilities over Time",
@@ -124,8 +124,8 @@ def _build_chart_html(records) -> tuple[dict[str, str], dict[str, float]]:
                 x=dates,
                 y=total_assets,
                 name="Total Assets",
-                mode="lines+markers",
-                line={"color": "green"},
+                mode="lines",
+                line={"color": "rgba(34, 139, 34, 0.4)"},
             )
         )
         fig_summary.add_trace(
@@ -133,8 +133,8 @@ def _build_chart_html(records) -> tuple[dict[str, str], dict[str, float]]:
                 x=dates,
                 y=total_liabilities,
                 name="Total Liabilities",
-                mode="lines+markers",
-                line={"color": "red"},
+                mode="lines",
+                line={"color": "rgba(220, 20, 60, 0.4)"},
             )
         )
         fig_summary.add_trace(
@@ -142,8 +142,8 @@ def _build_chart_html(records) -> tuple[dict[str, str], dict[str, float]]:
                 x=dates,
                 y=net_worth,
                 name="Net Worth",
-                mode="lines+markers",
-                line={"color": "blue", "width": 3},
+                mode="lines",
+                line={"color": "#0066cc", "width": 3},
             )
         )
     fig_summary.update_layout(
@@ -153,6 +153,7 @@ def _build_chart_html(records) -> tuple[dict[str, str], dict[str, float]]:
         yaxis_tickprefix="$",
         yaxis_tickformat=",.0f",
         hovermode="x unified",
+        showlegend=False,
         height=400,
         margin={"t": 40, "b": 40, "l": 60, "r": 20},
     )

--- a/src/asset_manager/web/app.py
+++ b/src/asset_manager/web/app.py
@@ -79,6 +79,7 @@ def _build_chart_html(records) -> tuple[dict[str, str], dict[str, float]]:
         yaxis_tickprefix="$",
         yaxis_tickformat=",.0f",
         hovermode="x unified",
+        showlegend=False,
         height=300,
         margin={"t": 40, "b": 40, "l": 60, "r": 20},
     )
@@ -99,6 +100,7 @@ def _build_chart_html(records) -> tuple[dict[str, str], dict[str, float]]:
         yaxis_tickprefix="$",
         yaxis_tickformat=",.0f",
         hovermode="x unified",
+        showlegend=False,
         height=300,
         margin={"t": 40, "b": 40, "l": 60, "r": 20},
     )

--- a/src/asset_manager/web/templates/dashboard.html
+++ b/src/asset_manager/web/templates/dashboard.html
@@ -79,8 +79,7 @@
             padding: 0.75rem 1.5rem;
             display: flex;
             align-items: baseline;
-            justify-content: center;
-            gap: 0.5rem;
+            gap: 0.75rem;
         }
         .summary-card .value {
             font-size: 1.75rem;

--- a/src/asset_manager/web/templates/dashboard.html
+++ b/src/asset_manager/web/templates/dashboard.html
@@ -76,17 +76,19 @@
             background-color: #fff;
             border-radius: 8px;
             box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-            padding: 1.25rem 1.5rem;
-            text-align: center;
+            padding: 0.75rem 1.5rem;
+            display: flex;
+            align-items: baseline;
+            justify-content: center;
+            gap: 0.5rem;
         }
         .summary-card .value {
             font-size: 1.75rem;
             font-weight: 600;
-            margin-bottom: 0.25rem;
         }
         .summary-card .label {
             color: #666;
-            font-size: 0.9rem;
+            font-size: 1rem;
         }
         .summary-card.net-worth .value {
             color: #0066cc;

--- a/src/asset_manager/web/templates/dashboard.html
+++ b/src/asset_manager/web/templates/dashboard.html
@@ -66,12 +66,51 @@
             margin: 0 auto;
             padding: 2rem;
         }
+        .summary-cards {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 1rem;
+            margin-bottom: 1.5rem;
+        }
+        .summary-card {
+            background-color: #fff;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+            padding: 1.25rem 1.5rem;
+            text-align: center;
+        }
+        .summary-card .value {
+            font-size: 1.75rem;
+            font-weight: 600;
+            margin-bottom: 0.25rem;
+        }
+        .summary-card .label {
+            color: #666;
+            font-size: 0.9rem;
+        }
+        .summary-card.net-worth .value {
+            color: #0066cc;
+        }
+        .summary-card.assets .value {
+            color: #22863a;
+        }
+        .summary-card.liabilities .value {
+            color: #cb2431;
+        }
         .chart-container {
             background-color: #fff;
             border-radius: 8px;
             box-shadow: 0 1px 3px rgba(0,0,0,0.1);
             margin-bottom: 1.5rem;
             padding: 1rem;
+        }
+        .chart-row {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 1.5rem;
+        }
+        .chart-row .chart-container {
+            margin-bottom: 0;
         }
         .error {
             background-color: #fee;
@@ -81,15 +120,18 @@
             border-radius: 4px;
             margin-bottom: 1rem;
         }
-        .info {
-            color: #666;
-            font-size: 0.9rem;
-            margin-bottom: 1rem;
-        }
         .no-data {
             text-align: center;
             padding: 2rem;
             color: #666;
+        }
+        @media (max-width: 768px) {
+            .summary-cards {
+                grid-template-columns: 1fr;
+            }
+            .chart-row {
+                grid-template-columns: 1fr;
+            }
         }
     </style>
 </head>
@@ -108,21 +150,33 @@
         <div class="error">{{ error }}</div>
         {% endif %}
 
-        {% if record_count %}
-        <p class="info">Showing {{ record_count }} records</p>
-        {% endif %}
-
         {% if charts %}
-        <div class="chart-container">
-            {{ charts.assets | safe }}
-        </div>
-
-        <div class="chart-container">
-            {{ charts.liabilities | safe }}
+        <div class="summary-cards">
+            <div class="summary-card net-worth">
+                <div class="value">${{ "{:,.0f}".format(totals.net_worth) }}</div>
+                <div class="label">Net Worth</div>
+            </div>
+            <div class="summary-card assets">
+                <div class="value">${{ "{:,.0f}".format(totals.assets) }}</div>
+                <div class="label">Assets</div>
+            </div>
+            <div class="summary-card liabilities">
+                <div class="value">${{ "{:,.0f}".format(totals.liabilities) }}</div>
+                <div class="label">Liabilities</div>
+            </div>
         </div>
 
         <div class="chart-container">
             {{ charts.summary | safe }}
+        </div>
+
+        <div class="chart-row">
+            <div class="chart-container">
+                {{ charts.assets | safe }}
+            </div>
+            <div class="chart-container">
+                {{ charts.liabilities | safe }}
+            </div>
         </div>
         {% else %}
         <div class="no-data">

--- a/src/asset_manager/web/templates/dashboard.html
+++ b/src/asset_manager/web/templates/dashboard.html
@@ -64,7 +64,7 @@
         .container {
             max-width: 1200px;
             margin: 0 auto;
-            padding: 2rem;
+            padding: 1rem;
         }
         .summary-cards {
             display: grid;


### PR DESCRIPTION
## Summary
Redesign the dashboard layout to match the new wireframe design.

## Changes
- **Summary cards**: Top row shows current Net Worth (blue), Assets (green), and Liabilities (red)
- **Net Worth chart**: Full-width chart showing Net Worth over Time
- **Assets/Liabilities charts**: Side-by-side below the main chart
- **Responsive**: Stacks vertically on mobile devices
- **Chart styling**: Lines only (no markers), legends hidden (hover for details)
- **Visual hierarchy**: Net Worth line is bold blue; Assets/Liabilities lines are faded in the summary chart

## Layout
```
┌─────────────┬─────────────┬─────────────┐
│  Net Worth  │   Assets    │ Liabilities │
│  $XXX,XXX   │  $XXX,XXX   │  $XXX,XXX   │
└─────────────┴─────────────┴─────────────┘
┌─────────────────────────────────────────┐
│         Net Worth over Time             │
│                                         │
└─────────────────────────────────────────┘
┌───────────────────┬─────────────────────┐
│ Assets over Time  │ Liabilities over    │
│                   │ Time                │
└───────────────────┴─────────────────────┘
```

## Test plan
- [ ] Run `ENV=dev uv run asset-manager serve`
- [ ] Verify summary cards show correct current values
- [ ] Verify charts display correctly with clean line styling
- [ ] Test hover interactions on charts
- [ ] Test responsive layout on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)