### PR TITLE
Add expandable breakdown to Assets and Liabilities cards

### DIFF
--- a/src/asset_manager/web/templates/dashboard.html
+++ b/src/asset_manager/web/templates/dashboard.html
@@ -94,6 +94,45 @@
             color: #999;
             font-size: 1.25rem;
             line-height: 1;
+            cursor: pointer;
+            transition: transform 0.2s ease;
+        }
+        .summary-card .chevron:hover {
+            color: #666;
+        }
+        .summary-card .chevron.expanded {
+            transform: rotate(180deg);
+        }
+        .card-wrapper {
+            position: relative;
+        }
+        .breakdown {
+            display: none;
+            background-color: #fff;
+            border-radius: 0 0 8px 8px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+            margin-top: -8px;
+            padding: 0.75rem 1.5rem;
+            padding-top: 1rem;
+        }
+        .breakdown.show {
+            display: block;
+        }
+        .breakdown-item {
+            display: flex;
+            justify-content: space-between;
+            padding: 0.25rem 0;
+            font-size: 0.9rem;
+            border-bottom: 1px solid #f0f0f0;
+        }
+        .breakdown-item:last-child {
+            border-bottom: none;
+        }
+        .breakdown-item .description {
+            color: #666;
+        }
+        .breakdown-item .amount {
+            font-weight: 500;
         }
         .summary-card.net-worth .value {
             color: #0066cc;
@@ -163,23 +202,43 @@
                 <div class="value">${{ "{:,.0f}".format(totals.net_worth) }}</div>
                 <div class="label">Net Worth</div>
             </div>
-            <div class="summary-card assets">
-                <div class="value">${{ "{:,.0f}".format(totals.assets) }}</div>
-                <div class="label">Assets</div>
-                <span class="chevron">
-                    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                        <path d="M4 6l4 4 4-4z"/>
-                    </svg>
-                </span>
+            <div class="card-wrapper">
+                <div class="summary-card assets">
+                    <div class="value">${{ "{:,.0f}".format(totals.assets) }}</div>
+                    <div class="label">Assets</div>
+                    <span class="chevron" onclick="toggleBreakdown('assets-breakdown', this)">
+                        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                            <path d="M4 6l4 4 4-4z"/>
+                        </svg>
+                    </span>
+                </div>
+                <div id="assets-breakdown" class="breakdown">
+                    {% for description, amount in assets_breakdown.items() %}
+                    <div class="breakdown-item">
+                        <span class="description">{{ description }}</span>
+                        <span class="amount">${{ "{:,.0f}".format(amount) }}</span>
+                    </div>
+                    {% endfor %}
+                </div>
             </div>
-            <div class="summary-card liabilities">
-                <div class="value">${{ "{:,.0f}".format(totals.liabilities) }}</div>
-                <div class="label">Liabilities</div>
-                <span class="chevron">
-                    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                        <path d="M4 6l4 4 4-4z"/>
-                    </svg>
-                </span>
+            <div class="card-wrapper">
+                <div class="summary-card liabilities">
+                    <div class="value">${{ "{:,.0f}".format(totals.liabilities) }}</div>
+                    <div class="label">Liabilities</div>
+                    <span class="chevron" onclick="toggleBreakdown('liabilities-breakdown', this)">
+                        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                            <path d="M4 6l4 4 4-4z"/>
+                        </svg>
+                    </span>
+                </div>
+                <div id="liabilities-breakdown" class="breakdown">
+                    {% for description, amount in liabilities_breakdown.items() %}
+                    <div class="breakdown-item">
+                        <span class="description">{{ description }}</span>
+                        <span class="amount">${{ "{:,.0f}".format(amount) }}</span>
+                    </div>
+                    {% endfor %}
+                </div>
             </div>
         </div>
 
@@ -201,5 +260,13 @@
         </div>
         {% endif %}
     </div>
+
+    <script>
+        function toggleBreakdown(breakdownId, chevron) {
+            const breakdown = document.getElementById(breakdownId);
+            breakdown.classList.toggle('show');
+            chevron.classList.toggle('expanded');
+        }
+    </script>
 </body>
 </html>

--- a/src/asset_manager/web/templates/dashboard.html
+++ b/src/asset_manager/web/templates/dashboard.html
@@ -71,6 +71,7 @@
             grid-template-columns: repeat(3, 1fr);
             gap: 1rem;
             margin-bottom: 1.5rem;
+            align-items: start;
         }
         .summary-card {
             background-color: #fff;

--- a/src/asset_manager/web/templates/dashboard.html
+++ b/src/asset_manager/web/templates/dashboard.html
@@ -89,6 +89,12 @@
             color: #666;
             font-size: 1rem;
         }
+        .summary-card .chevron {
+            margin-left: auto;
+            color: #999;
+            font-size: 1.25rem;
+            line-height: 1;
+        }
         .summary-card.net-worth .value {
             color: #0066cc;
         }
@@ -160,10 +166,20 @@
             <div class="summary-card assets">
                 <div class="value">${{ "{:,.0f}".format(totals.assets) }}</div>
                 <div class="label">Assets</div>
+                <span class="chevron">
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                        <path d="M4 6l4 4 4-4z"/>
+                    </svg>
+                </span>
             </div>
             <div class="summary-card liabilities">
                 <div class="value">${{ "{:,.0f}".format(totals.liabilities) }}</div>
                 <div class="label">Liabilities</div>
+                <span class="chevron">
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                        <path d="M4 6l4 4 4-4z"/>
+                    </svg>
+                </span>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Add dropdown chevron icons to Assets and Liabilities summary cards
- Click to expand and see breakdown of individual items with their current values

## Changes
- **Backend**: Extract latest value per description from time series data
- **Frontend**: Expandable breakdown sections with toggle animation
- **Styling**: Chevron rotates 180° when expanded, subtle item borders

## Test plan
- [ ] Run `ENV=dev uv run asset-manager serve`
- [ ] Click chevron on Assets card - should expand to show individual assets
- [ ] Click chevron on Liabilities card - should expand to show individual liabilities
- [ ] Verify Net Worth card doesn't resize when others expand
- [ ] Click again to collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)