### PR TITLE
Standardize for cluster deployment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: Continuous Integration
 
-on: push
+on:
+  pull_request:
+    branches: [main]
 
 jobs:
   lint:
@@ -8,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
       - name: Install uv
-        uses: astral-sh/setup-uv@v1
+        uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
       - name: Install Package and Dependencies
@@ -31,13 +33,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
       - name: Install uv
-        uses: astral-sh/setup-uv@v1
+        uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
       - name: Install Package and Dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,14 @@ RUN uv sync --frozen --no-dev --no-editable
 
 FROM python:3.13-slim
 
+RUN useradd --create-home --uid 1000 appuser
+
 WORKDIR /app
 COPY --from=builder /app /app
 
 ENV PATH="/app/.venv/bin:$PATH"
+
+USER appuser
 
 EXPOSE 8000
 

--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -2,5 +2,4 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: asset-manager-config
-data:
-  IDP_URL: "https://identity.ethanswan.com"
+data: {}

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
+          whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
               app: asset-manager
@@ -48,6 +48,13 @@ spec:
             limits:
               memory: "256Mi"
               cpu: "200m"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: secrets-store
               mountPath: "/mnt/secrets"

--- a/k8s/prod/configmap-env.yaml
+++ b/k8s/prod/configmap-env.yaml
@@ -4,3 +4,4 @@ metadata:
   name: asset-manager-prod-env-config
 data:
   ENV: "prod"
+  IDP_URL: "http://identity.identity-prod.svc.cluster.local"

--- a/k8s/prod/kustomization.yaml
+++ b/k8s/prod/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: asset-manager-prod
 
 resources:
   - ../base
+  - namespace.yaml
   - secret-provider-class.yaml
   - configmap-env.yaml
 

--- a/k8s/prod/namespace.yaml
+++ b/k8s/prod/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: asset-manager-prod

--- a/k8s/staging/configmap-env.yaml
+++ b/k8s/staging/configmap-env.yaml
@@ -3,4 +3,5 @@ kind: ConfigMap
 metadata:
   name: asset-manager-staging-env-config
 data:
-  ENV: "dev"
+  ENV: "staging"
+  IDP_URL: "http://identity.identity-staging.svc.cluster.local"

--- a/k8s/staging/kustomization.yaml
+++ b/k8s/staging/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: asset-manager-staging
 
 resources:
   - ../base
+  - namespace.yaml
   - secret-provider-class.yaml
   - configmap-env.yaml
 

--- a/k8s/staging/namespace.yaml
+++ b/k8s/staging/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: asset-manager-staging


### PR DESCRIPTION
## Summary
- Add non-root user to Dockerfile (appuser, uid 1000)
- Add pod securityContext (runAsNonRoot, drop ALL capabilities)
- Change topology constraint from DoNotSchedule to ScheduleAnyway
- Add namespace.yaml files for staging and prod
- Fix staging ENV value from "dev" to "staging"
- Move IDP_URL to per-environment configmaps with internal K8s DNS URLs
- Update CI workflow: PR trigger, bump actions to v4/v5, Python 3.13

## Test plan
- [x] `uv run ruff check` passes
- [x] `uv run ty check src/asset_manager` passes
- [ ] Verify K8s manifests render correctly with `kustomize build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)