### PR TITLE
Add Kubernetes service account manifests

### DIFF
--- a/k8s/prod/kustomization.yaml
+++ b/k8s/prod/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../base
   - namespace.yaml
   - secret-provider-class.yaml
+  - service-account.yaml
   - configmap-env.yaml
 
 patches:

--- a/k8s/prod/service-account.yaml
+++ b/k8s/prod/service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: asset-manager-prod-ksa
+  namespace: asset-manager-prod
+  annotations:
+    iam.gke.io/gcp-service-account: asset-manager-prod-sa@ethans-services.iam.gserviceaccount.com

--- a/k8s/staging/kustomization.yaml
+++ b/k8s/staging/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../base
   - namespace.yaml
   - secret-provider-class.yaml
+  - service-account.yaml
   - configmap-env.yaml
 
 patches:

--- a/k8s/staging/service-account.yaml
+++ b/k8s/staging/service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: asset-manager-staging-ksa
+  namespace: asset-manager-staging
+  annotations:
+    iam.gke.io/gcp-service-account: asset-manager-staging-sa@ethans-services.iam.gserviceaccount.com


### PR DESCRIPTION
## Summary
- Add KSA manifests for staging and prod with workload identity annotations
- Add to kustomization.yaml resources so ArgoCD manages them
- Fixes pod creation failure: the deployment references these KSAs but they didn't exist

## Test plan
- [ ] ArgoCD syncs and creates the KSAs
- [ ] Pods start successfully in both namespaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)