### PR TITLE
Add proxy headers support to uvicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ USER appuser
 
 EXPOSE 8000
 
-CMD ["uvicorn", "asset_manager.web.app:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "asset_manager.web.app:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "*"]


### PR DESCRIPTION
## Summary
- Add `--proxy-headers` and `--forwarded-allow-ips *` to uvicorn CMD
- Fixes OAuth redirect URIs generating `http://` instead of `https://` when behind Cloudflare Tunnel

## Test plan
- [ ] OAuth login flow uses `https://` redirect URI after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)