### PR TITLE
Use internal URLs for OAuth token/userinfo exchange

### DIFF
--- a/src/asset_manager/web/auth.py
+++ b/src/asset_manager/web/auth.py
@@ -50,6 +50,8 @@ def get_oauth() -> OAuth:
         client_id=client_id,
         client_secret=client_secret,
         server_metadata_url=f"{idp_url}/.well-known/openid-configuration",
+        access_token_url=f"{idp_url}/oauth/token",
+        userinfo_endpoint=f"{idp_url}/oauth/userinfo",
         token_endpoint_auth_method="client_secret_post",
         client_kwargs={
             "scope": "openid profile email",


### PR DESCRIPTION
## Summary
- Override `access_token_url` and `userinfo_endpoint` in authlib's OAuth registration to use the internal K8s URL (`IDP_URL`) instead of the public URL from OIDC discovery
- Fixes staging OAuth flow where Cloudflare Access intercepts server-to-server calls to the public identity URL and returns HTML instead of JSON

## Context
With the new Cloudflare Access-protected staging environment, pod-to-pod calls to `https://identity-staging.ethanswan.com` get blocked by CF Access. Browser redirects still use the public URL from metadata (correct), but token exchange and userinfo calls now go directly pod-to-pod via the internal URL.

No impact on prod — `IDP_URL` is already an internal K8s URL in both environments.

## Test plan
- [ ] Deploy to staging, test OAuth login flow at `https://assets-staging.ethanswan.com`
- [ ] Verify prod `https://assets.ethanswan.com` OAuth flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)