### PR TITLE
Revert CF Access workarounds for OAuth endpoints

### DIFF
--- a/src/asset_manager/web/auth.py
+++ b/src/asset_manager/web/auth.py
@@ -50,8 +50,6 @@ def get_oauth() -> OAuth:
         client_id=client_id,
         client_secret=client_secret,
         server_metadata_url=f"{idp_url}/.well-known/openid-configuration",
-        access_token_url=f"{idp_url}/oauth/token",
-        userinfo_endpoint=f"{idp_url}/oauth/userinfo",
         token_endpoint_auth_method="client_secret_post",
         client_kwargs={
             "scope": "openid profile email",


### PR DESCRIPTION
## Summary
- Remove `access_token_url` and `userinfo_endpoint` overrides from `oauth.register()`
- These were added in #17 to work around Cloudflare Access blocking server-to-server OAuth calls
- Switching to Tailscale for staging access instead, so the workarounds are no longer needed

## Test plan
- [ ] Verify prod OAuth flow at `https://assets.ethanswan.com` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)