### PR TITLE
Add Tailscale ingress for staging

### DIFF
--- a/k8s/staging/kustomization.yaml
+++ b/k8s/staging/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - secret-provider-class.yaml
   - service-account.yaml
   - configmap-env.yaml
+  - tailscale-ingress.yaml
 
 patches:
   - path: deployment-patch.yaml

--- a/k8s/staging/tailscale-ingress.yaml
+++ b/k8s/staging/tailscale-ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: asset-manager-staging-ts
+spec:
+  defaultBackend:
+    service:
+      name: asset-manager
+      port:
+        number: 80
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - assets-staging


### PR DESCRIPTION
## Summary
- Add a new `tailscale-ingress.yaml` resource that creates a Tailscale Ingress for the asset-manager staging environment, exposing it on the tailnet as `assets-staging` with TLS.
- Update `k8s/staging/kustomization.yaml` to include the new Tailscale ingress resource.

## Test plan
- [ ] Verify ArgoCD syncs the new ingress resource to the staging namespace
- [ ] Confirm the asset-manager staging service is reachable via Tailscale at `assets-staging`

🤖 Generated with [Claude Code](https://claude.com/claude-code)