### PR TITLE
Override OAuth endpoints to use internal K8s URL

### DIFF
--- a/src/asset_manager/web/auth.py
+++ b/src/asset_manager/web/auth.py
@@ -44,12 +44,17 @@ def get_oauth() -> OAuth:
             "CLIENT_ID and CLIENT_SECRET environment variables are required"
         )
 
-    # Register the OIDC provider with auto-discovery
+    # Register the OIDC provider with auto-discovery.
+    # Override server-to-server endpoints to use the internal K8s URL (IDP_URL)
+    # since pods can't resolve external hostnames (e.g. Tailscale MagicDNS).
     oauth.register(
         name="idp",
         client_id=client_id,
         client_secret=client_secret,
         server_metadata_url=f"{idp_url}/.well-known/openid-configuration",
+        token_endpoint=f"{idp_url}/oauth/token",
+        userinfo_endpoint=f"{idp_url}/oauth/userinfo",
+        jwks_uri=f"{idp_url}/.well-known/jwks.json",
         token_endpoint_auth_method="client_secret_post",
         client_kwargs={
             "scope": "openid profile email",


### PR DESCRIPTION
## Summary
- Override `token_endpoint`, `userinfo_endpoint`, and `jwks_uri` in the authlib OAuth registration to use the internal K8s URL (`IDP_URL`) instead of the external URLs from OIDC discovery
- Pods can't resolve Tailscale MagicDNS hostnames (`identity-staging.tailc06f30.ts.net`), so server-to-server OAuth calls (token exchange, userinfo) need to use internal K8s DNS

This is the same fix as PR #17, which was reverted in PR #19 when we removed CF Access workarounds. The same issue exists with Tailscale — external hostnames aren't resolvable from within the cluster.

## Test plan
- [ ] OAuth login flow works on `https://assets-staging.tailc06f30.ts.net`
- [ ] Token exchange succeeds (no "No address associated with hostname" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)