### PR TITLE
Remove redundant hand-rolled state in handle_login

### DIFF
--- a/src/asset_manager/web/auth.py
+++ b/src/asset_manager/web/auth.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import secrets
 import time
 import urllib.request
 from typing import Any
@@ -138,13 +137,8 @@ def clear_session_response(redirect_url: str) -> RedirectResponse:
 
 async def handle_login(request: Request, oauth: OAuth) -> RedirectResponse:
     """Redirect to the IDP for authentication."""
-    # Generate redirect URI based on request
     redirect_uri = str(request.url_for("auth_callback"))
-
-    # Generate and store PKCE state
-    state = secrets.token_urlsafe(32)
-
-    return await oauth.idp.authorize_redirect(request, redirect_uri, state=state)
+    return await oauth.idp.authorize_redirect(request, redirect_uri)
 
 
 async def handle_callback(request: Request, oauth: OAuth) -> RedirectResponse:


### PR DESCRIPTION
## Summary
- The hand-rolled `state = secrets.token_urlsafe(32)` in `handle_login` was redundant. authlib's `create_authorization_url` (oauth2/client.py:154 — `if state is None: state = generate_token()`) generates a CSRF state internally when none is supplied, and passing the hand-rolled one through ends up at the same `prepare_grant_uri` call identically.
- The `# Generate and store PKCE state` comment also conflated state (CSRF) with PKCE (code_verifier/code_challenge); those are independent mechanisms. PKCE is handled separately via `code_challenge_method` in `client_kwargs`.

## Test plan
- [x] `uv run ruff check src tests` passes
- [x] `uv run ty check src/asset_manager` passes
- [x] `uv run pytest` passes (20 passed, 1 skipped)
- [ ] After deploy, manually verify login flow still works end-to-end against staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)