### PR TITLE
fix: stop pinning staging to :latest (image-updater allow-tags)

### DIFF
--- a/k8s/argocd/applications.yaml
+++ b/k8s/argocd/applications.yaml
@@ -6,6 +6,9 @@ metadata:
   annotations:
     argocd-image-updater.argoproj.io/image-list: asset-manager=us-central1-docker.pkg.dev/ethans-services/containers/asset-manager
     argocd-image-updater.argoproj.io/asset-manager.update-strategy: newest-build
+    # Exclude the mutable `latest` tag so image-updater pins the immutable
+    # SHA tag instead of `:latest` (which it otherwise ties on by build time).
+    argocd-image-updater.argoproj.io/asset-manager.allow-tags: "regexp:^[a-f0-9]{7,}$"
 spec:
   project: default
   source:


### PR DESCRIPTION
## Problem

`argocd-image-updater` is configured with `update-strategy: newest-build` and **no tag filter**. Cloud Build pushes both `$SHORT_SHA` and `latest` for the same image (same digest, same build time), so when image-updater resolves the "newest build" it ties between `latest` and the newest `{sha}` tag and picks **`latest`** — pinning the staging Application's `kustomize.images` to `...:latest`.

As a result staging perpetually runs `:latest` instead of a real SHA, and the bifrost deploy dashboard reports this service's staging as **"unknown"** (an unparseable tag).

## Fix

Add an `allow-tags` regexp restricting candidate tags to immutable SHA tags (`^[a-f0-9]{7,}$`), excluding `latest`. image-updater then always pins the newest `{sha}` tag. This mirrors the working config already on `forecasting` and `bifrost`.

Staging-only; prod has no image-updater and is unaffected. **After merge**, re-apply the Application for it to take effect:
```
kubectl apply -f k8s/argocd/applications.yaml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
